### PR TITLE
fix: move onchainFailure abort logic to SDK

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -141,25 +141,7 @@ export default class Init extends Command {
         );
       } catch (e) {
         if (e instanceof OnchainFailureError) {
-          const sendAbort = await cli.confirm(
-            "Submitting onchain transaction failed. Send abort to merchant?"
-          );
-          if (sendAbort) {
-            const codeStr = await cli.prompt(
-              "Abort code to send [default: could_not_put_transaction]: ",
-              { default: "could_not_put_transaction" }
-            );
-            let code;
-            switch (codeStr) {
-              case "insufficient_funds":
-                code = AbortCodes.INSUFFICIENT_FUNDS;
-                break;
-              case "could_not_put_transaction":
-              default:
-                code = AbortCodes.COULD_NOT_PUT_TRANSACTION;
-            }
-            await charge.abort(code);
-          }
+          cli.info(`Onchain Failure: ${e.code}`);
         }
       }
     } catch (e: unknown) {

--- a/packages/sdk/src/charge.ts
+++ b/packages/sdk/src/charge.ts
@@ -328,11 +328,16 @@ export class Charge {
       throw new Error('getInfo() has not been called');
     }
 
-    await this.initCharge(payerData);
-
-    await this.readyForSettlement();
-
-    await this.submitTransactionOnChain();
+    try {
+      await this.initCharge(payerData);
+      await this.readyForSettlement();
+      await this.submitTransactionOnChain();
+    } catch (e) {
+      if (e instanceof OnchainFailureError) {
+        this.abort(e.code);
+        throw e;
+      }
+    }
   }
 
   /**

--- a/packages/sdk/src/charge.ts
+++ b/packages/sdk/src/charge.ts
@@ -334,7 +334,7 @@ export class Charge {
       await this.submitTransactionOnChain();
     } catch (e) {
       if (e instanceof OnchainFailureError) {
-        this.abort(e.code);
+        await this.abort(e.code);
         throw e;
       }
     }

--- a/packages/sdk/src/charge.ts
+++ b/packages/sdk/src/charge.ts
@@ -328,9 +328,10 @@ export class Charge {
       throw new Error('getInfo() has not been called');
     }
 
+    await this.initCharge(payerData);
+    await this.readyForSettlement();
+
     try {
-      await this.initCharge(payerData);
-      await this.readyForSettlement();
       await this.submitTransactionOnChain();
     } catch (e) {
       if (e instanceof OnchainFailureError) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

SDK now initiates an abort on a chain error, rather than the client.

- **What is the current behavior?** (You can also link to an open issue here)

The SDK consumer detects a thrown error then requests that the server abort the transaction.

- **What is the new behavior (if this is a feature change)?**
The SDK detects a thrown error then requests that the server abort the transaction.


- **Other information**:
