### PR TITLE
fix: Switch to arrow methods in classes to prevent context issues

### DIFF
--- a/packages/sdk/src/charge.ts
+++ b/packages/sdk/src/charge.ts
@@ -223,7 +223,7 @@ export class Charge {
    *
    * @returns
    */
-  async getInfo(): Promise<PaymentInfo> {
+  getInfo = async () => {
     const getPaymentInfoRequest: GetPaymentInfoRequest = {
       method: GetPaymentInfoRequest.method.value,
       params: {
@@ -249,7 +249,7 @@ export class Charge {
    * @param payerData
    * @returns
    */
-  async initCharge(payerData: PayerData): Promise<void> {
+  initCharge = async (payerData: PayerData): Promise<void> => {
     // TODO: validate payerData contains all required fields by this.paymentInfo.requiredPayerData
     const transactionHash = await this.chainHandler.computeTransactionHash(
       this.paymentInfo
@@ -281,7 +281,7 @@ export class Charge {
    * @returns
    */
 
-  async readyForSettlement() {
+  readyForSettlement = async () => {
     const readyForSettlementRequest: ReadyForSettlementRequest = {
       method: ReadyForSettlementRequest.method.value,
       params: {
@@ -302,7 +302,7 @@ export class Charge {
    *
    * @returns
    */
-  async submitTransactionOnChain() {
+   submitTransactionOnChain = async () => {
     if (!this.paymentInfo) {
       throw new Error('getInfo() has not been called');
     }
@@ -328,7 +328,7 @@ export class Charge {
    * @param payerData
    * @returns
    */
-  async submit(payerData: PayerData): Promise<void> {
+  submit = async (payerData: PayerData): Promise<void> => {
     if (!this.paymentInfo) {
       throw new Error('getInfo() has not been called');
     }
@@ -349,7 +349,7 @@ export class Charge {
   /**
    * Aborts a request
    */
-  async abort(code: AbortCodes, message?: string) {
+  abort = async (code: AbortCodes, message?: string) =>  {
     const abortRequest: AbortRequest = {
       method: AbortRequest.method.value,
       params: {

--- a/packages/sdk/src/handlers/contract-kit.ts
+++ b/packages/sdk/src/handlers/contract-kit.ts
@@ -12,8 +12,8 @@ import { ChainHandler } from './interface';
  */
 export class ContractKitTransactionHandler implements ChainHandler {
   private signedTransaction?: EncodedTransaction;
-  private readonly blockchainAddress;
-  private readonly dekAddress;
+  private readonly blockchainAddress: string;
+  private readonly dekAddress: string;
 
   constructor(private readonly kit: ContractKit) {
     [this.blockchainAddress, this.dekAddress] = this.kit
@@ -25,7 +25,7 @@ export class ContractKitTransactionHandler implements ChainHandler {
     }
   }
 
-  getSendingAddress() {
+  getSendingAddress = () => {
     return this.blockchainAddress;
   }
 
@@ -72,21 +72,21 @@ export class ContractKitTransactionHandler implements ChainHandler {
     return this.signedTransaction;
   }
 
-  async hasSufficientBalance(info: PaymentInfo) {
+  hasSufficientBalance = async (info: PaymentInfo) => {
     const { currency, amount: amntToSpend } = info.action;
     const sender = this.getSendingAddress();
     const balances = await this.kit.getTotalBalance(sender);
     return balances[currency].gte(amntToSpend);
   }
 
-  async computeTransactionHash(info: PaymentInfo) {
+  computeTransactionHash = async (info: PaymentInfo) => {
     const {
       tx: { hash },
     } = await this.getSignedTransaction(info);
     return hash;
   }
 
-  async submitTransaction(info: PaymentInfo) {
+  submitTransaction = async (info: PaymentInfo) => {
     const { raw } = await this.getSignedTransaction(info);
     const receipt = await (
       await this.kit.connection.sendSignedTransaction(raw)
@@ -95,7 +95,7 @@ export class ContractKitTransactionHandler implements ChainHandler {
     return receipt.transactionHash;
   }
 
-  async signTypedPaymentRequest(typedData: EIP712TypedData) {
+  signTypedPaymentRequest = async (typedData: EIP712TypedData) => {
     if (this.dekAddress) {
       return serializeSignature(
         await this.kit.signTypedData(this.dekAddress, typedData)
@@ -104,11 +104,11 @@ export class ContractKitTransactionHandler implements ChainHandler {
     return undefined;
   }
 
-  async getChainId() {
+  getChainId = () => {
     return this.kit.web3.eth.getChainId();
   }
 
-  async getDataEncryptionKey(account: string): Promise<string> {
+  getDataEncryptionKey = async (account: string): Promise<string> => {
     const accounts = await this.kit.contracts.getAccounts();
     return accounts.getDataEncryptionKey(account);
   }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
If the sdk class methods were called by other functions e.g. with redux-saga the `this` keyword would change and break the functions.

- **What is the new behavior (if this is a feature change)?**
Uses arrow functions to set context on definition.
